### PR TITLE
Add TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/styled-media-query.common.js",
   "module": "dist/styled-media-query.es.js",
   "jsnext:main": "dist/styled-media-query.es.js",
+  "types": "./src/index.d.ts",
   "repository": "git@github.com:morajabi/styled-media-query.git",
   "keywords": [
     "styled-components",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for styled-media-query 2.0.2
+// Type definitions for styled-media-query 2.1.1
 // Project: https://github.com/morajabi/styled-media-query
 // Definitions by: François Best <https://github.com/franky47>
-// TypeScript version: 3.1.6
+// Requires @types/styled-components definitions ^4.1
+// TypeScript version: 3.3.3
 
 import {
   ThemedStyledProps,
@@ -16,6 +17,7 @@ type InterpolationFunction<Props, Theme> = (
 type GeneratorFunction<Props, Theme> = (
   strings: TemplateStringsArray,
   ...interpolations: (
+    | InterpolationValue
     | InterpolationFunction<Props, Theme>
     | FlattenInterpolation<ThemedStyledProps<Props, Theme>>)[]
 ) => any

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for styled-media-query 2.0.2
+
+type GeneratorFunction<Theme> = <P>(
+  strings: TemplateStringsArray,
+  ...interpolations: (any)[]
+) => any
+
+// --
+
+export interface MediaGenerator<Breakpoints, Theme> {
+  lessThan: (breakpoint: keyof Breakpoints) => GeneratorFunction<Theme>
+  greaterThan: (breakpoint: keyof Breakpoints) => GeneratorFunction<Theme>
+  between: (
+    fist: keyof Breakpoints,
+    second: keyof Breakpoints
+  ) => GeneratorFunction<Theme>
+}
+
+// --
+
+export interface DefaultBreakpoints {
+  huge: string
+  large: string
+  medium: string
+  small: string
+}
+
+export const defaultBreakpoints: DefaultBreakpoints
+
+// --
+
+export function generateMedia<Breakpoints = DefaultBreakpoints, Theme = any>(
+  breakpoints?: Breakpoints
+): MediaGenerator<Breakpoints, Theme>
+
+// --
+
+declare const media: MediaGenerator<DefaultBreakpoints, any>
+
+export default media

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,14 +3,20 @@
 // Definitions by: François Best <https://github.com/franky47>
 // TypeScript version: 3.1.6
 
-import { ThemedStyledProps, FlattenInterpolation } from 'styled-components'
+import {
+  ThemedStyledProps,
+  InterpolationValue,
+  FlattenInterpolation
+} from 'styled-components'
+
+type InterpolationFunction<Props, Theme> = (
+  props: ThemedStyledProps<Props, Theme>
+) => InterpolationValue | FlattenInterpolation<ThemedStyledProps<Props, Theme>>
 
 type GeneratorFunction<Props, Theme> = (
   strings: TemplateStringsArray,
   ...interpolations: (
-    | ((
-        props: ThemedStyledProps<Props, Theme>
-      ) => string | FlattenInterpolation<ThemedStyledProps<Props, Theme>>)
+    | InterpolationFunction<Props, Theme>
     | FlattenInterpolation<ThemedStyledProps<Props, Theme>>)[]
 ) => any
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,19 +1,32 @@
 // Type definitions for styled-media-query 2.0.2
+// Project: https://github.com/morajabi/styled-media-query
+// Definitions by: François Best <https://github.com/franky47>
+// TypeScript version: 3.1.6
 
-type GeneratorFunction<Theme> = <P>(
+import { ThemedStyledProps, FlattenInterpolation } from 'styled-components'
+
+type GeneratorFunction<Props, Theme> = (
   strings: TemplateStringsArray,
-  ...interpolations: (any)[]
+  ...interpolations: (
+    | ((
+        props: ThemedStyledProps<Props, Theme>
+      ) => string | FlattenInterpolation<ThemedStyledProps<Props, Theme>>)
+    | FlattenInterpolation<ThemedStyledProps<Props, Theme>>)[]
 ) => any
 
 // --
 
 export interface MediaGenerator<Breakpoints, Theme> {
-  lessThan: (breakpoint: keyof Breakpoints) => GeneratorFunction<Theme>
-  greaterThan: (breakpoint: keyof Breakpoints) => GeneratorFunction<Theme>
-  between: (
+  lessThan: <Props>(
+    breakpoint: keyof Breakpoints
+  ) => GeneratorFunction<Props, Theme>
+  greaterThan: <Props>(
+    breakpoint: keyof Breakpoints
+  ) => GeneratorFunction<Props, Theme>
+  between: <Props>(
     fist: keyof Breakpoints,
     second: keyof Breakpoints
-  ) => GeneratorFunction<Theme>
+  ) => GeneratorFunction<Props, Theme>
 }
 
 // --

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -51,3 +51,8 @@ export function generateMedia<Breakpoints = DefaultBreakpoints, Theme = any>(
 declare const media: MediaGenerator<DefaultBreakpoints, any>
 
 export default media
+
+// Convertors --
+
+export function pxToEm<B>(breakpoints: B, ratio?: number): B
+export function pxToRem<B>(breakpoints: B, ratio?: number): B


### PR DESCRIPTION
Relates to issue #3.

Brings the following TypeScript features:
- [x] `import media from 'styled-media-query'` in a TypeScript file
- [x] Define a custom media object with given breakpoints
- [x] Connect ThemeInterface from `styled-components` to default or custom `media` object
- [x] Use custom props types when creating media-queried styled components
- [x] Intellisense for theme and custom props

I'll edit this message with the usage API for documentation once the depending PRs (#14, #15 and [DefinitelyTyped#30511](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30511)) have been merged.