### PR TITLE
Proposal for V3 chainable API

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,6 +25,7 @@ type GeneratorFunction<Props, Theme> = (
 // --
 
 export interface MediaGenerator<Breakpoints, Theme> {
+  styled: <Props> () => InterpolationFunction<Props, Theme>
   lessThan: <Props>(
     breakpoint: keyof Breakpoints
   ) => GeneratorFunction<Props, Theme>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,7 +25,6 @@ type GeneratorFunction<Props, Theme> = (
 // --
 
 export interface MediaGenerator<Breakpoints, Theme> {
-  styled: <Props> () => InterpolationFunction<Props, Theme>
   lessThan: <Props>(
     breakpoint: keyof Breakpoints
   ) => GeneratorFunction<Props, Theme>

--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,7 @@ export function generateMedia(breakpoints = defaultBreakpoints) {
 export class GenerateMediaChained extends Function {
   /**
    * Constructor to chain `generateMedia()` and still bind the class to itself.
+   *
    * @param breakpoints   Object    The initial breakpoint object.
    * @return {any}
    */

--- a/src/index.js
+++ b/src/index.js
@@ -34,8 +34,6 @@ function getSizeFromBreakpoint(breakpointValue, breakpoints = {}) {
  * @return {Object} - Media generators for each breakpoint
  */
 export function generateMedia(breakpoints = defaultBreakpoints) {
-  const styled = (...args) => css(...args);
-
   const lessThan = (breakpoint) => (...args) => css`
     @media (max-width: ${getSizeFromBreakpoint(breakpoint, breakpoints)}) {
       ${css(...args)}
@@ -95,29 +93,62 @@ export function generateMedia(breakpoints = defaultBreakpoints) {
   );
 }
 
-// TODO: comments
+/**
+ * Generate Media as a chained callable class by extending Function.
+ * (Proposal for V3)
+ */
 export class GenerateMediaChained extends Function {
+  /**
+   * Constructor to chain `generateMedia()` and still bind the class to itself.
+   * @param breakpoints   Object    The initial breakpoint object.
+   * @return {any}
+   */
   constructor(breakpoints = defaultBreakpoints) {
+    // Call parent constuctor, making this a function.
     super('...args', 'return this.__self__.__call__(...args)');
+    // Reestablish context by binding to this.
     const self = this.bind(this);
     this.__self__ =  self;
+    // As we have to return an instance of `self` with bound this, create the
+    // class variables on it. `callees` will later be a bound creator.
     self.callees = []
     self.media = generateMedia(breakpoints)
     return self;
   }
 
+  /**
+   * Wrapper around `lessThan()`.
+   * At the moment we have to reset the length of `callees` as long as chaining
+   * isn't discussed further.
+   *
+   * @param breakpoint    String|Number   Breakpoint to create Media-query from.
+   * @return {GenerateMediaChained}
+   */
   lessThan (breakpoint) {
     if (this.callees.length > 1) this.callees = []
     this.callees.push(this.media.lessThan(breakpoint))
     return this;
   }
 
+  /**
+   * Wrapper around `greaterThan()`
+   *
+   * @param breakpoint    String|Number   Breakpoint to create Media-query from.
+   * @return {GenerateMediaChained}
+   */
   greaterThan (breakpoint) {
     if (this.callees.length > 1) this.callees = []
     this.callees.push(this.media.greaterThan(breakpoint))
     return this;
   }
 
+  /**
+   * Wrapper around `between()`.
+   *
+   * @param firstBreakpoint   String|Number  Lower bound breakpoint.
+   * @param secondBreakpoint  String|Number  Upper bound breakpoint.
+   * @return {GenerateMediaChained}
+   */
   between (firstBreakpoint, secondBreakpoint) {
     if (typeof firstBreakpoint === "string") this.css(firstBreakpoint)
     if (this.callees.length > 1) this.callees = []
@@ -125,10 +156,25 @@ export class GenerateMediaChained extends Function {
     return this;
   }
 
+  /**
+   * Finalizing function (like jQuerys' `end()`).
+   * Tried to replicate the highlighting for styled-components with this, but
+   * sadly doesn't work.
+   *
+   * @param args    String    The css to give to the functions in `callees`.
+   * @return {*}
+   */
   css (...args) {
     return this.callees[0](...args)
   }
 
+  /**
+   * Same as `css()`. But now our class is a callable.
+   *
+   * @param args    String    The css to give to the functions in `callees`.
+   * @return {*}
+   * @private
+   */
   __call__ (...args) {
     return this.css(...args)
   }


### PR DESCRIPTION
As #11 is open long enough and I like the ideas in the latest comments of `styled-media-query` becoming chainable, I looked for ways we could accomplish this. 
As ES only has a proposal for making classes also callable, I searched a little and stumbled upon [this gem](https://gist.github.com/arccoza/471ec4a2dfc246c703948db6e99ebb9f) and worked from it to be able to call the `generateMedia()` functions in an arbitrary manner:

Using it is possible like this:

```js
const media = new GenerateMediaChained();
...
// Later in a styled-component:
`${media.greaterThan('medium').css`flex:1`}`
// But the following (calling the class driectly) works as well : ).
`${media.greaterThan('medium')`flex:1`}`
// And one could even do this, but atm only the last function in the chain will be used in the end:
`${media.greaterThan('medium').lessThan('small')`flex:1`}`
```

So we'd have the possibility to go at chaining like the proposed

```js
${media.for('retina')`
   display: flex;
`};

${media.width.between('sm', 'lg').for('retina')`
   display: block;
`};
```

As now it's easy to add `aliases` and `features` as well and still be able to chain the functions in an arbitrary manner : ).