### PR TITLE
fix(definition-types): accept custom string for all functions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,60 +7,64 @@
 import {
   ThemedStyledProps,
   InterpolationValue,
-  FlattenInterpolation
-} from 'styled-components'
+  FlattenInterpolation,
+} from "styled-components";
 
 type InterpolationFunction<Props, Theme> = (
   props: ThemedStyledProps<Props, Theme>
-) => InterpolationValue | FlattenInterpolation<ThemedStyledProps<Props, Theme>>
+) => InterpolationValue | FlattenInterpolation<ThemedStyledProps<Props, Theme>>;
 
 type GeneratorFunction<Props, Theme> = (
   strings: TemplateStringsArray,
   ...interpolations: (
     | InterpolationValue
     | InterpolationFunction<Props, Theme>
-    | FlattenInterpolation<ThemedStyledProps<Props, Theme>>)[]
-) => any
+    | FlattenInterpolation<ThemedStyledProps<Props, Theme>>
+  )[]
+) => any;
 
 // --
 
 export interface MediaGenerator<Breakpoints, Theme> {
-  lessThan: <Props>(
+  lessThan<Props>(
     breakpoint: keyof Breakpoints
-  ) => GeneratorFunction<Props, Theme>
-  greaterThan: <Props>(
+  ): GeneratorFunction<Props, Theme>;
+  lessThan<Props>(breakpoint: string): GeneratorFunction<Props, Theme>;
+  greaterThan<Props>(
     breakpoint: keyof Breakpoints
-  ) => GeneratorFunction<Props, Theme>
-  between: <Props>(
+  ): GeneratorFunction<Props, Theme>;
+  greaterThan<Props>(breakpoint: string): GeneratorFunction<Props, Theme>;
+  between<Props>(
     fist: keyof Breakpoints,
     second: keyof Breakpoints
-  ) => GeneratorFunction<Props, Theme>
+  ): GeneratorFunction<Props, Theme>;
+  between<Props>(fist: string, second: string): GeneratorFunction<Props, Theme>;
 }
 
 // --
 
 export interface DefaultBreakpoints {
-  huge: string
-  large: string
-  medium: string
-  small: string
+  huge: string;
+  large: string;
+  medium: string;
+  small: string;
 }
 
-export const defaultBreakpoints: DefaultBreakpoints
+export const defaultBreakpoints: DefaultBreakpoints;
 
 // --
 
 export function generateMedia<Breakpoints = DefaultBreakpoints, Theme = any>(
   breakpoints?: Breakpoints
-): MediaGenerator<Breakpoints, Theme>
+): MediaGenerator<Breakpoints, Theme>;
 
 // --
 
-declare const media: MediaGenerator<DefaultBreakpoints, any>
+declare const media: MediaGenerator<DefaultBreakpoints, any>;
 
-export default media
+export default media;
 
 // Convertors --
 
-export function pxToEm<B>(breakpoints: B, ratio?: number): B
-export function pxToRem<B>(breakpoints: B, ratio?: number): B
+export function pxToEm<B>(breakpoints: B, ratio?: number): B;
+export function pxToRem<B>(breakpoints: B, ratio?: number): B;


### PR DESCRIPTION
Closes #23 #21 

## Description

This PR adds a function overload for media.* functions that allow we pass a custom size via string or a specific media query name.

**First implementation**
![image](https://user-images.githubusercontent.com/12464600/85795105-03eaea00-b738-11ea-9535-8f3e26890e66.png)

**Secondimplementation**
![image](https://user-images.githubusercontent.com/12464600/85795098-02212680-b738-11ea-90c3-592a35d0fbe4.png)

**Result in VSCode**
![image](https://user-images.githubusercontent.com/12464600/85795091-ff263600-b737-11ea-8aab-6adbaf5fcdfd.png)

