### PR TITLE
add 'px' complement to getSizeFromBreakpoint

### DIFF
--- a/src/convertors.js
+++ b/src/convertors.js
@@ -10,7 +10,7 @@ function pxToEmOrRem(breakpoints, ratio = 16, unit) {
   for (let key in breakpoints) {
     const point = breakpoints[key];
 
-    if (String(point).includes('px')) {
+    if (typeof point === 'number' || String(point).includes('px')) {
       newBreakpoints[key] = +(parseInt(point) / ratio) + unit;
       continue;
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,10 +44,10 @@ export interface MediaGenerator<Breakpoints, Theme> {
 // --
 
 export interface DefaultBreakpoints {
-  huge: string;
-  large: string;
-  medium: string;
-  small: string;
+  huge: string | number;
+  large: string | number;
+  medium: string | number;
+  small: string | number;
 }
 
 export const defaultBreakpoints: DefaultBreakpoints;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -66,5 +66,11 @@ export default media;
 
 // Convertors --
 
-export function pxToEm<B>(breakpoints: B, ratio?: number): B;
-export function pxToRem<B>(breakpoints: B, ratio?: number): B;
+export function pxToEm<B extends DefaultBreakpoints>(
+  breakpoints: B,
+  ratio?: number
+): B;
+export function pxToRem<B extends DefaultBreakpoints>(
+  breakpoints: B,
+  ratio?: number
+): B;

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,9 @@ export const defaultBreakpoints = {
 };
 
 function getSizeFromBreakpoint(breakpointValue, breakpoints = {}) {
-  if (breakpoints[breakpointValue]) {
+  if (typeof breakpoints[breakpointValue] === "number") {
+    return breakpoints[breakpointValue] + "px";
+  } else if (breakpoints[breakpointValue]) {
     return breakpoints[breakpointValue];
   } else if (parseInt(breakpointValue)) {
     return breakpointValue;


### PR DESCRIPTION
Hi. First, I'm grateful for the very nice module.
This PR implements #30.

- Add completion of __px__ to number in `getSizeFromBreakpoint`
- Add number to DefaultBreakpoints type
- Enable to convert number as **px** in `pxToEmOrRem`
- Add generics constraint to `pxToEr` and `pxToRem`